### PR TITLE
Improve documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Go workspace file
 go.work
+
+# macs create this for indexing
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@
 The [`ohno`](pkg/ohno) package on the other hand will help you to add more information to an error like source location information (file, line, function) along with timestamps, custom messages, nesting and joining. This also has friendly helper methods to marshal your errors in to `json` or `yaml` formats.
 
 You can use either [`ohnogen`](cmd/ohnogen) tool or the [`ohno`](pkg/ohno) package independently of each other based on your use case subject certain interface constraints being met when using the [`ohno`](pkg/ohno) package standalone which is explained in the [`ohno`](pkg/ohno) package documentation. You can however use the [`ohnogen`](cmd/ohnogen) tool to generate your errors and use them without the [`ohno`](pkg/ohno) package as long as you don't want additional context being stored in your error.
+
+## Go References
+
+- **[ohno](https://pkg.go.dev/github.com/A-0-5/ohno@v0.0.1/pkg/ohno)**
+- **[ohnogen](https://pkg.go.dev/github.com/A-0-5/ohno/cmd/ohnogen)**
+- **[usage examples](https://pkg.go.dev/github.com/A-0-5/ohno/examples)**

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,8 @@
+# Usage examples
+
+There are 2 ways you can use `ohnogen`. One is with the `-ohno` option which will allow you to add additional context to your errors with the `ohno` package. The other is without the `-ohno` option which will allow you to directly use the errors as simple values.
+
+## Go References
+
+- [**usage example with** `-ohno`](https://pkg.go.dev/github.com/A-0-5/ohno@v0.0.1/examples/usage_with_ohno)
+- [**usage example without** `-ohno`](https://pkg.go.dev/github.com/A-0-5/ohno@v0.0.1/examples/usage_without_ohno)

--- a/pkg/sourceinfo/source_info.go
+++ b/pkg/sourceinfo/source_info.go
@@ -3,7 +3,9 @@
 //
 // author: A.O.S
 
-package sourceinfo
+// package sourceinfo is a helper around runtime Caller which simplifies
+// fetching source information using frames.
+package sourceinfo // import "github.com/A-0-5/ohno/pkg/sourceinfo"
 
 import (
 	"path"


### PR DESCRIPTION
This commit adds the missing go doc links to key portions of the repo in the main readme file.  It  also  adds  a  new  readme  in  the  examples directory giving a brief about its usage.

closes #1