### PR TITLE
Fix field alignments for structs

### DIFF
--- a/pkg/ohno/ohno_error.go
+++ b/pkg/ohno/ohno_error.go
@@ -188,11 +188,11 @@ func (o *OhNoError) removeCauseAndAppendRecursive(errs []error) []error {
 }
 
 type ohNoMarshalError struct {
+	CausedBy    error                         `json:"caused_by,omitempty" yaml:"caused_by,omitempty"`
+	SourceInfo  *sourceinfo.SourceInformation `json:"source_information,omitempty" yaml:"source_information,omitempty"`
 	Package     string                        `json:"package" yaml:"package"`
 	Code        string                        `json:"code" yaml:"code"`
 	Name        string                        `json:"name" yaml:"name"`
 	Description string                        `json:"description" yaml:"description"`
 	TimeStamp   string                        `json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
-	SourceInfo  *sourceinfo.SourceInformation `json:"source_information,omitempty" yaml:"source_information,omitempty"`
-	CausedBy    error                         `json:"caused_by,omitempty" yaml:"caused_by,omitempty"`
 }

--- a/pkg/sourceinfo/source_info.go
+++ b/pkg/sourceinfo/source_info.go
@@ -36,8 +36,8 @@ const (
 // This structure contains the information about the source code.
 type SourceInformation struct {
 	File     string `json:"file" yaml:"file"`
-	Line     int    `json:"line" yaml:"line"`
 	Function string `json:"function,omitempty" yaml:"function,omitempty"`
+	Line     int    `json:"line" yaml:"line"`
 }
 
 // This function prints the source information in the format


### PR DESCRIPTION
This commit contains a minor  memory  enhancement  where  the  effective struct struct size in memory for SourceInformation and  ohNoMarshalError have been reduced using the fieldalignment tool.

closes #4